### PR TITLE
Add timeout variable

### DIFF
--- a/tmr.el
+++ b/tmr.el
@@ -74,7 +74,7 @@ such notifications."
           (const :tag "Critical" critical)))
 
 (defcustom tmr-notification-timeout -1
-  "The timeout time in milliseconds since the notification disappears.
+  "The timeout time duration in milliseconds since the notification disappears.
 Values can be `-1' (default) or `0' (never expire).
 
 With `-1', It depends on the daemon and may vary for type of notification."

--- a/tmr.el
+++ b/tmr.el
@@ -73,6 +73,15 @@ such notifications."
           (const :tag "Normal" normal)
           (const :tag "Critical" critical)))
 
+(defcustom tmr-notification-timeout -1
+  "The timeout time in milliseconds since the notification disappears.
+Values can be `-1' (default) or `0' (never expire).
+
+With `-1', It depends on the daemon and may vary for type of notification."
+  :type 'integer
+  :options '(-1 0)
+  :group 'tmr)
+
 (defcustom tmr-sound-file
   "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga"
   "Path to sound file used by `tmr-sound-play'.

--- a/tmr.el
+++ b/tmr.el
@@ -378,6 +378,7 @@ Read: (info \"(elisp) Desktop Notifications\") for details."
          :title title
          :body body
          :app-name "GNU Emacs"
+         :timeout tmr-notification-timeout
          :urgency tmr-notification-urgency
          :sound-file tmr-sound-file))
     (warn "Emacs has no DBUS support, TMR notifications unavailable")))


### PR DESCRIPTION
It gives the user an option to control the timeout duration of notification appearance on the screen.