### PR TITLE
Silence ffplay without shell redirection

### DIFF
--- a/tmr.el
+++ b/tmr.el
@@ -556,8 +556,7 @@ TIMER is unused."
               ((file-exists-p sound)))
     (unless (executable-find "ffplay")
       (user-error "Cannot play %s without `ffplay'" sound))
-    (call-process-shell-command
-     (format "ffplay -nodisp -autoexit -loglevel -8 %s" sound) nil 0)))
+    (start-process "tmr-sound-play" nil "ffplay" "-nodisp" "-autoexit" "-loglevel" "-8" sound)))
 
 (defun tmr-print-message-for-created-timer (timer)
   "Show a `message' informing the user that TIMER was created."


### PR DESCRIPTION
## Back Story

- I recently switched from zsh to [nushell](https://www.nushell.sh/book/coming_from_bash.html), and tmr stopped playing sound.
- I discovered that `nu` was being used by `call-process-shell-command`, and it didn't like the Bourne-styled output redirection and the `ffplay` command didn't run.
- I passed it `-loglevel -8` to silence ffplay instead.
- This should be portable to more shells