### PR TITLE
Add native macOS notifications via osascript

### DIFF
--- a/README.org
+++ b/README.org
@@ -353,25 +353,36 @@ TMR provides the following hooks:
 
 #+vindex: tmr-sound-file
 #+vindex: tmr-notification-urgency
-Once the timer has run its course, it produces a desktop notification and
-plays an alarm sound.  The notification's message is practically the same
-as that which is sent to the echo area.
+Once the timer has run its course, it produces a desktop notification
+and plays an alarm sound.  The notification's message is practically
+the same as that which is sent to the echo area.
 
-The sound file for the alarm is defined in ~tmr-sound-file~, while the
-urgency of the notification can be set through the user option
-~tmr-notification-urgency~.  Note that it is up to the desktop
-environment or notification daemon to decide how to handle the urgency
-value.
+The sound file for the alarm is defined in ~tmr-sound-file~.  On Linux
+this should be a path to an audio file; on macOS it is the name of a
+built-in alert sound (see below).  The urgency of the notification can
+be set through the user option ~tmr-notification-urgency~.  Note that
+it is up to the desktop environment or notification daemon to decide
+how to handle the urgency value.
 
-If the ~tmr-sound-file~ is nil, or the file is not found, no sound will
-be played.
+If the ~tmr-sound-file~ is nil, or the value is not found, no sound
+will be played.
 
-Sound playback depends on the =ffplay= executable which is part of
-=ffmpeg=.
+Desktop notifications and sound playback behave differently depending
+on the platform:
 
-Desktop notifications work only if Emacs is built with DBus
-functionality.  This is the norm.  If such functionality is not
-available, TMR will issue a warning informing the user accordingly.
+- On Linux, notifications require Emacs to be built with DBus
+  functionality.  This is the norm for most distributions.  If DBus is
+  not available, TMR will issue a warning.  Sound playback depends on
+  the =ffplay= executable which is part of =ffmpeg=.
+- On macOS, notifications and sound are handled natively via
+  =osascript= (the AppleScript interpreter bundled with the OS; see
+  [[https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/DisplayNotifications.html#//apple_ref/doc/uid/TP40016239-CH61-SW1][Apple's documentation on notifications]]).  No
+  additional dependencies are required.  Set ~tmr-sound-file~ to the
+  name of one of the built-in macOS alert sounds: =Basso=, =Blow=,
+  =Bottle=, =Frog=, =Funk=, =Glass=, =Hero=, =Morse=, =Ping=, =Pop=,
+  =Purr=, =Sosumi=, =Submarine=, =Tink=.
+- On Windows and Android, the platform's native notification API is
+  used automatically.
 
 ** Minibuffer histories
 :PROPERTIES:
@@ -452,13 +463,17 @@ Everything is in place to set up the package.
 #+cindex: Package configuration
 
 #+begin_src emacs-lisp
-(use-package tmr
-  :ensure t
-  :config
-  (define-key global-map (kbd "C-c t") #'tmr-prefix-map)
-  (setq tmr-sound-file "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga"
-        tmr-notification-urgency 'normal
-        tmr-description-list 'tmr-description-history))
+  (use-package tmr
+    :ensure t
+    :config
+    (define-key global-map (kbd "C-c t") #'tmr-prefix-map)
+    (setq tmr-sound-file "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga"
+          tmr-notification-urgency 'normal
+          tmr-description-list 'tmr-description-history))
+
+    ;; macOS specific
+    (when (eq system-type 'darwin)
+      (setq tmr-macos-notification-sound "Glass"))
 #+end_src
 
 * Integration with Embark

--- a/tmr.el
+++ b/tmr.el
@@ -654,6 +654,20 @@ If there are no timers, throw an error."
 (declare-function android-notifications-notify "androidselect.c" (&rest params))
 (declare-function w32-notification-notify "w32fns.c" (&rest params))
 (declare-function haiku-notifications-notify "haikuselect.c" (&rest params))
+
+(cl-defun macos-notification-notify (&key title body sound-file)
+  "Send a native MacOS notification for TITLE, BODY and SOUND-FILE.
+
+SOUND-FILE must be a macOS system sound name such as \"Glass\", not a
+file path.  File paths (including the default value of `tmr-sound-file')
+are intentionally ignored to prevent the Linux default path from being
+passed to osascript, which would fall back to a default system sound
+unexpectedly."
+  (let* ((sound (when (and sound-file (not (file-name-directory sound-file))) (format " sound name %S" sound-file)))
+         (sanitized-body (substring-no-properties body))
+         (script (format "display notification %S with title %S%s" sanitized-body title (or sound ""))))
+    (call-process "osascript" nil 0 nil "-e" script)))
+
 (defvar notifications-application-icon)
 
 (defvar tmr--notification-notify-count 0
@@ -667,7 +681,8 @@ Read Info node `(elisp) Desktop Notifications' for details."
         (seq-some #'fboundp
                   (list #'android-notifications-notify
                         #'w32-notification-notify
-                        #'haiku-notifications-notify)))
+                        #'haiku-notifications-notify))
+        (eq system-type 'darwin))
     (let ((title "TMR May Ring (Emacs tmr package)")
           (body (tmr--long-description-for-finished-timer timer)))
       (setq tmr--notification-notify-count 0)
@@ -687,6 +702,11 @@ Read Info node `(elisp) Desktop Notifications' for details."
          :body body
          :app-icon 'emacs
          :urgency tmr-notification-urgency))
+       ((eq system-type 'darwin)
+        (macos-notification-notify
+         :title title
+         :body body
+         :sound-file tmr-sound-file))
        (t
         (unless (fboundp 'notifications-notify)
           (require 'notifications))


### PR DESCRIPTION
Hey! This adds support for native macOS notifications  [(Apple docs)](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/DisplayNotifications.html#//apple_ref/doc/uid/TP40016239-CH61-SW1). 


1. Adds macOS support to `tmr-notification-notify` via a new helper
function `macos-notification-notify` that uses macOS `osascript` 
instead of DBus, which is not available on macOS.

2. File paths passed as `sound-file` are intentionally ignored to
prevent the Linux default value of `tmr-sound-file' from triggering
an unexpected system sound on macOS.
