### PR TITLE
documentation for tmr-timer-finished-functions hook

### DIFF
--- a/README.org
+++ b/README.org
@@ -340,6 +340,33 @@ TMR provides the following hooks:
   a message in the echo area which is basically the same as the desktop
   notification.
 
+  This hook can be used as an extension point for custom notification
+  mechanisms. To replace or augment the default desktop notification,
+  remove ~tmr-notification-notify~ and add your own function:
+
+  #+begin_src emacs-lisp
+  (remove-hook 'tmr-timer-finished-functions #'tmr-notification-notify)
+  (add-hook 'tmr-timer-finished-functions #'my-custom-notify-function)
+  #+end_src
+
+  The function receives a timer.
+
+  Below is an example of how a macOS notification could be produced:
+
+  #+begin_src emacs-lisp
+  (defun my-macos-notify (timer)
+    (let* ((description (or (tmr--timer-description timer) ""))
+           (sanitized-body (substring-no-properties description))
+           (script (format "display notification %S with title %S sound name %S"
+    	  		     sanitized-body
+    	  		     (format-time-string "Emacs TMR: %R" (tmr--timer-end-date timer))
+    	  		     "Hero")))
+      (call-process "osascript" nil 0 nil "-e" script)))
+
+  (remove-hook 'tmr-timer-finished-functions #'tmr-notification-notify)
+  (add-hook 'tmr-timer-finished-functions #'my-macos-notify)
+  #+end_src
+
 #+vindex: tmr-timer-cancelled-functions
 + ~tmr-timer-cancelled-functions~ :: This is called by ~tmr-cancel~.  By
   default, it prints a message in the echo area describing the timer that


### PR DESCRIPTION
This PR updates the documentation for `tmr-timer-finished-functions` stating that it is possible to hook-up custom notification mechanisms. Provides an example of a macOS notification thing.

The matter is being discussed in https://github.com/protesilaos/tmr/issues/24. 